### PR TITLE
[fixes] check if exception has attribute startswith

### DIFF
--- a/erpnext_shopify/api.py
+++ b/erpnext_shopify/api.py
@@ -40,23 +40,17 @@ def sync_shopify_resources():
 				message= "Updated {customers} customer(s), {products} item(s), {orders} order(s)".format(**frappe.local.form_dict.count_dict))
 
 		except Exception, e:
-			if e.args[0] and e.args[0].startswith("402"):
-				make_shopify_log(
-					title="Shopify has suspended your account",
-					status="Error",
-					method="sync_shopify_resources",
-					message=_("""Shopify has suspended your account till you complete the payment. We have disabled ERPNext Shopify Sync. Please enable it once your complete the payment at Shopify."""),
-					exception=True)
-					
+			if e.args[0] and hasattr(e.args[0], "startswith") and e.args[0].startswith("402"):
+				make_shopify_log(title="Shopify has suspended your account", status="Error",
+					method="sync_shopify_resources", message=_("""Shopify has suspended your account till
+					you complete the payment. We have disabled ERPNext Shopify Sync. Please enable it once
+					your complete the payment at Shopify."""), exception=True)
+
 				disable_shopify_sync_on_exception()
 			
 			else:
-				make_shopify_log(
-					title="sync has terminated",
-					status="Error",
-					method="sync_shopify_resources",
-					message=frappe.get_traceback(),
-					exception=True)
+				make_shopify_log(title="sync has terminated", status="Error", method="sync_shopify_resources",
+					message=frappe.get_traceback(), exception=True)
 					
 	elif frappe.local.form_dict.cmd == "erpnext_shopify.api.sync_shopify":
 		make_shopify_log(


### PR DESCRIPTION
```
Method: hourly_long, Handler: erpnext_shopify.api.sync_shopify_resources
Traceback (innermost last):
  File "/home/frappe/v5press/benches/1606030848/apps/frappe/frappe/tasks.py", line 114, in scheduler_task
    frappe.get_attr(handler)()
  File "/home/frappe/v5press/benches/1606030848/apps/erpnext_shopify/erpnext_shopify/api.py", line 43, in sync_shopify_resources
    if e.args[0] and e.args[0].startswith("402"):
 AttributeError: 'int' object has no attribute 'startswith'
```

@nabinhait Urgent.
