### PR TITLE
Add dynamic link to create_customer_address

### DIFF
--- a/erpnext_shopify/sync_customers.py
+++ b/erpnext_shopify/sync_customers.py
@@ -55,7 +55,7 @@ def create_customer_address(customer, shopify_customer):
 	for i, address in enumerate(shopify_customer.get("addresses")):
 		address_title, address_type = get_address_title_and_type(customer.customer_name, i)
 		try :
-			frappe.get_doc({
+			new_address = frappe.get_doc({
 				"doctype": "Address",
 				"shopify_address_id": address.get("id"),
 				"address_title": address_title,
@@ -70,6 +70,16 @@ def create_customer_address(customer, shopify_customer):
 				"email_id": shopify_customer.get("email"),
 				"customer": customer.name,
 				"customer_name":  customer.customer_name
+			}).insert()
+			
+			# create dynamic link
+			dynamic_link = frappe.get_doc({
+				"doctype": "Dynamic Link",
+				"parent": new_address.name,
+				"parenttype": "Address",
+				"parentfield": "links",
+				"link_doctype": "Customer",
+				"link_name": customer.name
 			}).insert()
 			
 		except Exception, e:


### PR DESCRIPTION
This is needed to assign the address to the customer. I've assigned the doc of the new address to the variable new_address, because I think it's more clear to use new_address.name when creating the dynamic link.

dynamic_link = ... might me not necessary, but thats up to the core team to decide. What do you think?