### PR TITLE
[minor] typo fix in create_new_item_to_shopify method call

### DIFF
--- a/erpnext_shopify/sync_products.py
+++ b/erpnext_shopify/sync_products.py
@@ -376,7 +376,7 @@ def sync_item_with_shopify(item, price_list, warehouse):
 	erp_item.flags.ignore_mandatory = True
 	
 	if not item.get("shopify_product_id"):
-		create_new_item_to_shopify(ite, item_data, erp_item, variant_item_name_list)
+		create_new_item_to_shopify(item, item_data, erp_item, variant_item_name_list)
 
 	else:
 		item_data["product"]["id"] = item.get("shopify_product_id")


### PR DESCRIPTION
`Error Traceback`

```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext_shopify/erpnext_shopify/sync_products.py", line 339, in sync_erpnext_items
    sync_item_with_shopify(item, price_list, warehouse)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext_shopify/erpnext_shopify/sync_products.py", line 379, in sync_item_with_shopify
    create_new_item_to_shopify(ite, item_data, erp_item, variant_item_name_list)
NameError: global name 'ite' is not defined
```