### PR TITLE
[minor] check if e.args is avalible fix for IndexError: tuple index out of range

### DIFF
--- a/erpnext_shopify/sync_orders.py
+++ b/erpnext_shopify/sync_orders.py
@@ -26,7 +26,7 @@ def sync_shopify_orders():
 				make_shopify_log(status="Error", method="sync_shopify_orders", message=frappe.get_traceback(),
 					request_data=shopify_order, exception=True)
 			except Exception, e:
-				if e.args[0] and e.args[0].startswith("402"):
+				if e.args and e.args[0] and e.args[0].startswith("402"):
 					raise e
 				else:
 					make_shopify_log(title=e.message, status="Error", method="sync_shopify_orders", message=frappe.get_traceback(),


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext_shopify/issues/149

```
Traceback (most recent call last):
  File "/home/ubuntu/frappe-bench/apps/erpnext_shopify/erpnext_shopify/api.py", line 34, in sync_shopify_resources
    sync_orders()
  File "/home/ubuntu/frappe-bench/apps/erpnext_shopify/erpnext_shopify/sync_orders.py", line 13, in sync_orders
    sync_shopify_orders()
  File "/home/ubuntu/frappe-bench/apps/erpnext_shopify/erpnext_shopify/sync_orders.py", line 29, in sync_shopify_orders
    if e.args[0] and e.args[0].startswith("402"):
IndexError: tuple index out of range
```