### PR TITLE
[minor] removed the group icon-sitemap from custom button

### DIFF
--- a/erpnext_shopify/erpnext_shopify/doctype/shopify_settings/shopify_settings.js
+++ b/erpnext_shopify/erpnext_shopify/doctype/shopify_settings/shopify_settings.js
@@ -34,12 +34,11 @@ frappe.ui.form.on("Shopify Settings", "refresh", function(frm){
 		frm.toggle_reqd("sales_invoice_series", frm.doc.sync_sales_invoice);
 		frm.toggle_reqd("delivery_note_series", frm.doc.sync_delivery_note);
 
-		frm.add_custom_button(__('Sync Shopify'),
-			function() {
-				frappe.call({
-					method:"erpnext_shopify.api.sync_shopify",
-				})
-			}, 'icon-sitemap')
+		frm.add_custom_button(__('Sync Shopify'), function() {
+			frappe.call({
+				method:"erpnext_shopify.api.sync_shopify",
+			})
+		}).addClass("btn-primary");
 	}
 
 	if(!frm.doc.access_token && !frm.doc.api_key) {


### PR DESCRIPTION
`before`
<img width="1181" alt="screen shot 2017-05-22 at 5 15 58 pm" src="https://cloud.githubusercontent.com/assets/11224291/26307543/c5df2852-3f12-11e7-8ffb-641bca0b3d9c.png">

`after`
<img width="1178" alt="screen shot 2017-05-22 at 5 16 48 pm" src="https://cloud.githubusercontent.com/assets/11224291/26307548/ccb67b44-3f12-11e7-9150-da8cf807fb54.png">
