### PR TITLE
Change variant name

### DIFF
--- a/erpnext_shopify/sync_products.py
+++ b/erpnext_shopify/sync_products.py
@@ -150,7 +150,7 @@ def create_item_variants(shopify_item, warehouse, attributes, shopify_variants_a
 			shopify_item_variant = {
 				"id" : variant.get("id"),
 				"item_code": variant.get("id"),
-				"title": variant.get("title"),
+				"title": shopify_item.get("title") + ": " + variant.get("title"),
 				"product_type": shopify_item.get("product_type"),
 				"sku": variant.get("sku"),
 				"uom": template_item.stock_uom or _("Nos"),


### PR DESCRIPTION
When variants have the same name, they get overwritten (Example: Shirt A: Medium / Blue, Shirt B: Medium / Blue). To prevent this i changed the variant name to the following format: "Template name": "Variant name".